### PR TITLE
added additional visibility to datepicker label for opening month and yearpicker

### DIFF
--- a/src/components/Datepicker/DatepickerHeader.tsx
+++ b/src/components/Datepicker/DatepickerHeader.tsx
@@ -70,7 +70,8 @@ const DatepickerHeader: React.FC<DatepickerHeaderProps> = ({
           text-center
           bold
           p-2
-          ${showYearPicker ? '' : 'hover:bg-primary-100 cursor-pointer'}
+          text-primary-500
+          ${showYearPicker ? '' : 'hover:bg-primary-100 active:text-grayscale-light-white active:bg-primary-600 cursor-pointer'}
         `
       }
         onClick={showMonthPicker ? openYearPicker : openMonthPicker}


### PR DESCRIPTION
ref: https://github.com/avionschool/platform/issues/101

- added additional visibility to datepicker label for opening month and yearpicker
- Datepicker on mobile
<img width="294" alt="Datepicker mobile cta" src="https://user-images.githubusercontent.com/65531311/194268260-6c4d5f03-9204-49a0-bc2a-4ee8d852846a.png">
- Datepicker on desktop
<img width="1440" alt="Datepicker desktop cta" src="https://user-images.githubusercontent.com/65531311/194268286-5c7318d0-268b-42b6-a163-4a15edc3e88b.png">
- Datepicker on desktop when hovered 
<img width="1436" alt="Datepicker hover cta" src="https://user-images.githubusercontent.com/65531311/194268313-4b2475f9-c3c8-4851-b610-c342c5c6de3d.png">
